### PR TITLE
Ignore Sanctum CSRF

### DIFF
--- a/config/pretty-routes.php
+++ b/config/pretty-routes.php
@@ -57,6 +57,7 @@ return [
         '#^_ignition#',
         '#^horizon#',
         '#^routes#',
+        '#^sanctum/csrf-cookie#',
         '#^telescope#',
     ],
 

--- a/config/pretty-routes.php
+++ b/config/pretty-routes.php
@@ -57,7 +57,7 @@ return [
         '#^_ignition#',
         '#^horizon#',
         '#^routes#',
-        '#^sanctum/csrf-cookie#',
+        '#^sanctum#',
         '#^telescope#',
     ],
 


### PR DESCRIPTION
`laravel/sanctum gets required for new setups of Laravel for CSRF protection, but there could be other routes for it so focusing just this specific route.