### PR TITLE
feat: allow customization of styles by publishing vendor files

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -41,6 +41,7 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->publishes([
             $this->fullPath('config/pretty-routes.php') => $this->app->configPath('pretty-routes.php'),
+            $this->fullPath('resources/views/styles.blade.php') => resource_path('views/vendor/pretty-routes/styles.blade.php'),
         ]);
 
         $this->loadRoutesFrom(

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -41,7 +41,7 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->publishes([
             $this->fullPath('config/pretty-routes.php') => $this->app->configPath('pretty-routes.php'),
-            $this->fullPath('resources/views/styles.blade.php') => resource_path('views/vendor/pretty-routes/styles.blade.php'),
+            $this->fullPath('resources/views/styles.blade.php') => $this->app->resourcePath('views/vendor/pretty-routes/styles.blade.php'),
         ]);
 
         $this->loadRoutesFrom(


### PR DESCRIPTION
The vendor files are published to `resources/views/vendor/<package>` by default, following Laravel conventions (for example, Laravel pulse does that already).

If the file exist in that location, Laravel automatically sources the customized file instead of the default package one.

If users do not want to override any vendor files, they can simply add `resources/views/vendor/` or `vendor/**` to gitignore.